### PR TITLE
fixed wtf behavior of esp_mqtt_client_publish

### DIFF
--- a/navDev/src/mqttClient.c
+++ b/navDev/src/mqttClient.c
@@ -164,7 +164,7 @@ static void mqttClientTask( void *pvParameter )
 static void mqttClientPacketSend( char *packet, void *client )
 {
     esp_mqtt_client_handle_t hClient = (esp_mqtt_client_handle_t)client;
-    ESP_LOGI( TAG, "esp_mqtt_client_publish, ret/msg_id=%d", esp_mqtt_client_publish( hClient, CONFIG_MQTT_TOPIC_DATA, packet , 0, 1, 0 ) ); 
+    ESP_LOGI( TAG, "esp_mqtt_client_publish, ret/msg_id=%d", esp_mqtt_client_publish( hClient, CONFIG_MQTT_TOPIC_DATA, packet , strlen(packet), 2, 0 ) ); 
 }
 /*============================================================================*/
 esp_err_t mqttClientStart( QueueHandle_t messageQueue, EventGroupHandle_t eventGroup )


### PR DESCRIPTION
according to "esp_mqtt_client_publish" docs :
_len: data length, if set to 0, length is calculated from payload string_
well, it seems that the 0 argument does not work.
:angry:  :angry: :angry: :angry:

also, just in case, I increased the qos=2